### PR TITLE
feat: enable hubble ui

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
@@ -28,6 +28,33 @@ gatewayAPI:
   enabled: true
 hubble:
   enabled: false
+  metrics:
+    enabled:
+      - dns:query;ignoreAAAA
+      - drop
+      - tcp
+      - flow
+      - port-distribution
+      - icmp
+      - http
+      - kafka
+    enableOpenMetrics: true
+    serviceMonitor:
+      enabled: true
+  relay:
+    enabled: true
+    rollOutPods: true
+    prometheus:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+  ui:
+    enabled: true
+    rollOutPods: true
+    service:
+      type: ClusterIP
+    ingress:
+      enabled: true
 ipam:
   mode: kubernetes
 ipv4NativeRoutingCIDR: "10.41.0.0/16"


### PR DESCRIPTION
This pull request introduces several enhancements to the Hubble observability stack within the Cilium Helm chart configuration. The changes enable various metrics, monitoring, and UI components to improve visibility into network traffic and performance.

**Hubble metrics and monitoring enhancements:**

* Enabled multiple Hubble metrics, including DNS queries (with `ignoreAAAA`), drop, TCP, flow, port distribution, ICMP, HTTP, and Kafka, and set `enableOpenMetrics` to true for Prometheus compatibility.
* Activated Hubble `serviceMonitor` for Prometheus integration.

**Hubble Relay improvements:**

* Enabled Hubble Relay, with pod rollout and Prometheus monitoring (`serviceMonitor` enabled).

**Hubble UI enhancements:**

* Enabled Hubble UI, set pod rollout, configured the service as `ClusterIP`, and enabled ingress for external access.